### PR TITLE
Updated default.rb to point to the 7.1 repo

### DIFF
--- a/specs/default/chef/site-cookbooks/beegfs/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/beegfs/attributes/default.rb
@@ -1,5 +1,5 @@
-default["beegfs"]["repo_file_url"] = "https://www.beegfs.io/release/beegfs_7/dists/beegfs-rhel7.repo"
-default["beegfs"]["rpm_gpg_key"] = "https://www.beegfs.io/release/beegfs_7/gpg/RPM-GPG-KEY-beegfs"
+default["beegfs"]["repo_file_url"] = "https://www.beegfs.io/release/beegfs_7_1/dists/beegfs-rhel7.repo"
+default["beegfs"]["rpm_gpg_key"] = "https://www.beegfs.io/release/beegfs_7_1/gpg/RPM-GPG-KEY-beegfs"
 
 # the directory on the MGS, MDS and OSS where the BeeGFS data resides
 default["beegfs"]["root_dir"] = "/data/beegfs"


### PR DESCRIPTION
I tried to use a newer version of the client that works with OFED 4.5 (with a patch) and I could not get the 7.1.2 client to talk with a 7.0 server. So I have updated the repo version of BeeGFS to point to the latest stable release.

Please review and let me know if you have any questions.