### PR TITLE
replace fdisk with parted

### DIFF
--- a/specs/default/chef/site-cookbooks/azvolumes/files/default/create-nvme-array.sh
+++ b/specs/default/chef/site-cookbooks/azvolumes/files/default/create-nvme-array.sh
@@ -30,19 +30,9 @@ setup_storage_disks()
 
     for disk in $Disks; do
         #disk=`readlink -f /dev/disk/azure/scsi1/lun$lun`
-        fdisk -l $disk || break
-        fdisk $disk << EOF
-n
-p
-1
-
-
-t
-fd
-w
-EOF
+        parted -s $disk -- mklabel gpt
+        parted -s $disk -- mkpart primary 0% 100%
         createdPartitions="$createdPartitions ${disk}p1"
-
     done
     sleep 10
     mkdir -p $mountPoint

--- a/specs/default/chef/site-cookbooks/azvolumes/files/default/create-premium-array.sh
+++ b/specs/default/chef/site-cookbooks/azvolumes/files/default/create-premium-array.sh
@@ -21,17 +21,8 @@ setup_storage_disks()
 
     for lun in $LUNS; do
         disk=`readlink -f /dev/disk/azure/scsi1/lun$lun`
-        fdisk -l $disk || break
-        fdisk $disk << EOF
-n
-p
-1
-
-
-t
-fd
-w
-EOF
+        parted -s $disk -- mklabel gpt
+        parted -s $disk -- mkpart primary 0% 100%
         createdPartitions="$createdPartitions ${disk}1"
     done
     sleep 10

--- a/specs/default/chef/site-cookbooks/azvolumes/files/default/setup-nvme-mdadm.sh
+++ b/specs/default/chef/site-cookbooks/azvolumes/files/default/setup-nvme-mdadm.sh
@@ -30,17 +30,8 @@ setup_storage_disks()
 
     for disk in $Disks; do
         #disk=`readlink -f /dev/disk/azure/scsi1/lun$lun`
-        fdisk -l $disk || break
-        fdisk $disk << EOF
-n
-p
-1
-
-
-t
-fd
-w
-EOF
+        parted -s $disk -- mklabel gpt
+        parted -s $disk -- mkpart primary 0% 100%
         createdPartitions="$createdPartitions ${disk}p1"
 
     done


### PR DESCRIPTION
setup scripts use fdisk to partition the disks but its limited to 2TB partitions.  Since this is creating a single partition on the disk it limits the disk size to 2TB.  To support larger disks I changed the scripts to use parted instead of fdisk.